### PR TITLE
fix: don't lock base path at `grep` and `rg` Curators

### DIFF
--- a/builtin/curator/grep.ts
+++ b/builtin/curator/grep.ts
@@ -40,11 +40,10 @@ const pattern = new RegExp("^(.*?):(\\d+):(.*)$");
  * @returns A Curator that yields search results in the form of `GrepDetail`.
  */
 export function grep(options: GrepOptions = {}): Curator<Detail> {
-  let base: string;
   return defineCurator(
     async function* (denops, { args, query }, { signal }) {
       // Determine the root directory for the grep command
-      base ??= await getAbsolutePathOf(denops, args[0] ?? ".", signal);
+      const base = await getAbsolutePathOf(denops, args[0] ?? ".", signal);
 
       // Configure the `grep` command with the provided query
       const cmd = new Deno.Command("grep", {

--- a/builtin/curator/rg.ts
+++ b/builtin/curator/rg.ts
@@ -38,11 +38,10 @@ const pattern = new RegExp("^(.*?):(\\d+):(\\d+):(.*)$");
  * @returns A Curator that yields search results in the form of `RgDetail`.
  */
 export function rg(options: RgOptions = {}): Curator<Detail> {
-  let base: string;
   return defineCurator(
     async function* (denops, { args, query }, { signal }) {
       // Determine the root directory for the rg command
-      base ??= await getAbsolutePathOf(denops, args[0] ?? ".", signal);
+      const base = await getAbsolutePathOf(denops, args[0] ?? ".", signal);
 
       // Configure the `rg` command with the provided query
       const cmd = new Deno.Command("rg", {


### PR DESCRIPTION
Currently `base` is accidentually permanent state. I'll fix it.