### PR TITLE
fix: Use @denops/std/helper/getbufinfo instead

### DIFF
--- a/builtin/source/buffer.ts
+++ b/builtin/source/buffer.ts
@@ -1,5 +1,6 @@
 import { unreachable } from "@core/errorutil/unreachable";
-import * as fn from "@denops/std/function";
+import type * as fn from "@denops/std/function";
+import { getbufinfo } from "@denops/std/helper/getbufinfo";
 
 import { defineSource, type Source } from "../../source.ts";
 
@@ -44,7 +45,7 @@ type Filter = "buflisted" | "bufloaded" | "bufmodified";
 export function buffer(options: Readonly<BufferOptions> = {}): Source<Detail> {
   const filter = options.filter;
   return defineSource(async function* (denops, _params, { signal }) {
-    const bufinfo = await fn.getbufinfo(denops);
+    const bufinfo = await getbufinfo(denops);
     signal?.throwIfAborted();
 
     // Filter and map buffers based on the provided filter option

--- a/builtin/source/line.ts
+++ b/builtin/source/line.ts
@@ -1,4 +1,5 @@
 import * as fn from "@denops/std/function";
+import { getbufinfo } from "@denops/std/helper/getbufinfo";
 
 import { defineSource, type Source } from "../../source.ts";
 
@@ -50,7 +51,7 @@ export function line(options: LineOptions = {}): Source<Detail> {
     const expr = args[0] ?? "%"; // Defaults to the current buffer if no argument is provided.
     await fn.bufload(denops, expr); // Ensure the buffer is loaded.
     signal?.throwIfAborted();
-    const bufinfos = await fn.getbufinfo(denops, expr); // Retrieve buffer information.
+    const bufinfos = await getbufinfo(denops, expr); // Retrieve buffer information.
     signal?.throwIfAborted();
     const bufinfo = bufinfos[0];
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -114,7 +114,7 @@
   "imports": {
     "@core/errorutil": "jsr:@core/errorutil@^1.2.0",
     "@core/iterutil": "jsr:@core/iterutil@^0.9.0",
-    "@denops/std": "jsr:@denops/std@^7.3.0",
+    "@denops/std": "jsr:@denops/std@^7.5.0",
     "@denops/test": "jsr:@denops/test@^3.0.4",
     "@lambdalisue/systemopen": "jsr:@lambdalisue/systemopen@^1.0.0",
     "@lambdalisue/unnullish": "jsr:@lambdalisue/unnullish@^1.0.2",


### PR DESCRIPTION
Related to: https://github.com/vim-denops/deno-denops-std/pull/279

As you know, the getbufinfo function in @denops/std/function will raise an error when there's a funcref in buffer-local variables. So, we should switch to the alternative getbufinfo function provided by @denops/std/helper/getbufinfo module.

I searched for "getbufinfo" by `rg getbufinfo` at the root of this repository, and changed all of them to the helper module's getbufinfo function.