### PR TITLE
Add optional previewPath to file previewer

### DIFF
--- a/builtin/previewer/file.ts
+++ b/builtin/previewer/file.ts
@@ -9,6 +9,7 @@ const decoder = new TextDecoder("utf-8", { fatal: true });
 
 type Detail = {
   path: string;
+  previewPath?: string;
   line?: number;
   column?: number;
 };
@@ -23,10 +24,12 @@ type Detail = {
  */
 export function file(): Previewer<Detail> {
   return definePreviewer(async (denops, { item }, { signal }) => {
+    const path = item.detail.previewPath ?? item.detail.path;
+
     // Resolve the absolute path of the file
-    const abspath = isAbsolute(item.detail.path)
-      ? item.detail.path
-      : await fn.fnamemodify(denops, item.detail.path, ":p");
+    const abspath = isAbsolute(path)
+      ? path
+      : await fn.fnamemodify(denops, path, ":p");
     signal?.throwIfAborted();
 
     try {


### PR DESCRIPTION
This PR introduces an optional `previewPath` property in `Detail`, which allows specifying a custom preview path for files.
If the `previewPath` is provided, it will be used for previewing the file.
Otherwise, the `path` will be used as a fallback.

This change allows for scenarios where an item’s `path` is a directory. For example, when the path points to a directory, it enables the previewing of a specific file like `README.md` inside that directory.

This update is backward compatible, so it won't affect existing functionality.

If there are existing features that can achieve the same functionality, please let me know.

The test coverage check is failing, but there are no similar tests for this change in the builtin extension, so I have left it on hold for now.